### PR TITLE
Launch stage from statespace.launch

### DIFF
--- a/autonomy_controller/launch/statespace.launch
+++ b/autonomy_controller/launch/statespace.launch
@@ -1,8 +1,30 @@
 <launch>
 
-    <include file="$(find multi_robot_path_planner)/launch/multi_bot_stage.launch">
-    <arg name="stage_sim" value="multi_bot_obstacles.launch" />
+
+
+    <!-- Stage -->
+    <arg name="stage_sim" default="multi_bot_obstacles" />
+
+    <include file="$(find ssr_stage)/launch/$(arg stage_sim).launch"/>
+
+
+    <include file="$(find multi_robot_path_planner)/launch/multi_bot_stage.launch" if="$(eval arg('stage_sim') == 'multi_bot_obstacles')">
+    <arg name="stage_sim" default="multi_bot_obstacles.launch"/>
     </include>
+
+    <include file="$(find multi_robot_path_planner)/launch/single_bot_stage.launch" if="$(eval arg('stage_sim') == 'single_bot_empty')">
+    <arg name="stage_sim" default="single_bot_empty.launch"/>
+    </include>
+
+    <include file="$(find multi_robot_path_planner)/launch/single_bot_stage_gmapping.launch" if="$(eval arg('stage_sim') == 'single_bot_obstacles')">
+    <arg name="stage_sim" default="single_bot_obstacles.launch"/>
+    </include>
+
+
+
+
+
+
 
     <node pkg="autonomy_controller" type="Total_State_Machine.py" name="state_machine" output="screen"/>
 

--- a/simulations/stage/worlds/single_bot_empty.world
+++ b/simulations/stage/worlds/single_bot_empty.world
@@ -14,7 +14,7 @@ include "dumper.inc"
 include "digger.inc"
 
 # Instantiate a dumper robot
-dumper( pose 0.945 0.75 0 0] name "dumper" color "red")
+dumper( pose [0.945 0.75 0 0] name "dumper" color "red")
 
 # Load obstacles here
 # Example:


### PR DESCRIPTION
#1 
Added ability to use argument stage_sim:= to be able to specify which launch file to run in command line, defaults to multi_robot.

To run single bot stage:
       `roslaunch autonomy_controller statespace.launch stage_sim:='single_bot_empty'` 
  To run single bot stage gmapping:
 `roslaunch autonomy_controller statespace.launch stage_sim:='single_bot_obstacles'` 



Also Side note I am having trouble running the two single bot stage simulations without getting errors.
Single_bot_gmapping:
![gmapping](https://user-images.githubusercontent.com/44686596/50264030-af8dde00-03cd-11e9-915b-0bc78b4296bb.PNG)
Single_bot_stage:
![single_bot_stage](https://user-images.githubusercontent.com/44686596/50264034-b583bf00-03cd-11e9-8d35-928a88a4e5e3.PNG)

This seems to happen when I am in the develop branch too, so I am unsure of the reason.